### PR TITLE
Temporarily remove living180 from django-debug-toolbar comittters

### DIFF
--- a/terraform/production/repositories.tfvars
+++ b/terraform/production/repositories.tfvars
@@ -79,7 +79,8 @@ repositories = {
     ]
     committers = [
       "elineda",
-      "living180",
+      # living180 needs to apply for Commons membership first
+      # "living180",
       "salty-ivy",
     ]
     members = [


### PR DESCRIPTION
This user is not a member of the organization yet. This causes Terraform to continually wanting to add them, creating noise in diffs. And possibly a lot of email invitation spam?

cc @cunla @tim-schilling @matthiask 