### PR TITLE
fix:GH pages support + manage repo-collaborators

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -17,4 +17,9 @@ locals {
   }
 
   users = merge(local.admins, local.members)
+
+  project_repositories = {
+    for repository_key, repository in var.repositories : repository_key => repository
+    if !repository.is_django_commons_repo
+  }
 }

--- a/terraform/production/repositories.tfvars
+++ b/terraform/production/repositories.tfvars
@@ -33,8 +33,8 @@ repositories = {
   }
 
   "django-commons-playground" = {
-    description = "A sample project to test things out"
-    topics      = []
+    description = "A sample project with best practices for Django Commons projects."
+    topics      = ["template", "django", "python"]
     # People with GitHub admin repo permissions
     admins = [
       "cunla",

--- a/terraform/production/repositories.tfvars
+++ b/terraform/production/repositories.tfvars
@@ -151,7 +151,6 @@ repositories = {
     has_wiki               = false
     is_template            = false
     push_allowances        = []
-    template               = ""
     topics = [
       "django",
       "django-application",

--- a/terraform/resources-collaborators.tf
+++ b/terraform/resources-collaborators.tf
@@ -1,0 +1,56 @@
+# This aims to remove all manually added users from the repository collaborators
+
+locals {
+  repo_collaborators = {
+    for key, value in local.project_repositories : key => [
+      {
+        team_id    = github_team.repo_admin_team[key].slug
+        permission = "admin"
+      },
+      {
+        team_id    = github_team.repo_committer_team[key].slug
+        permission = "maintain"
+      },
+      {
+        team_id    = github_team.repo_team[key].slug
+        permission = "triage"
+      },
+      {
+        team_id    = github_team.org_teams["security-team"].slug
+        permission = "pull"
+      }
+    ]
+  }
+}
+
+import {
+  for_each = local.project_repositories
+
+  id = each.key
+  to = github_repository_collaborators.this[each.key]
+}
+
+resource "github_repository_collaborators" "this" {
+  for_each = local.repo_collaborators
+
+  repository = github_repository.this[each.key].name
+  dynamic "team" {
+    for_each = local.repo_collaborators[each.key]
+    content {
+      team_id    = team.value.team_id
+      permission = team.value.permission
+    }
+  }
+  # team {
+  #   team_id    = github_team.repo_admin_team[each.key].id
+  #   permission = "admin"
+  # }
+  # team {
+  #   team_id    = github_team.repo_committer_team[each.key].id
+  #   permission = "maintain"
+  # }
+  # team {
+  #   team_id    = github_team.repo_team[each.key].id
+  #   permission = "triage"
+  # }
+}

--- a/terraform/resources-collaborators.tf
+++ b/terraform/resources-collaborators.tf
@@ -41,16 +41,4 @@ resource "github_repository_collaborators" "this" {
       permission = team.value.permission
     }
   }
-  # team {
-  #   team_id    = github_team.repo_admin_team[each.key].id
-  #   permission = "admin"
-  # }
-  # team {
-  #   team_id    = github_team.repo_committer_team[each.key].id
-  #   permission = "maintain"
-  # }
-  # team {
-  #   team_id    = github_team.repo_team[each.key].id
-  #   permission = "triage"
-  # }
 }

--- a/terraform/resources-environments.tf
+++ b/terraform/resources-environments.tf
@@ -1,5 +1,5 @@
 resource "github_repository_environment" "pypi" {
-  for_each = { for k, v in var.repositories : k => v if v.is_django_commons_repo == false }
+  for_each = local.project_repositories
 
   environment         = "pypi"
   repository          = each.key
@@ -10,7 +10,7 @@ resource "github_repository_environment" "pypi" {
 }
 
 resource "github_repository_environment" "testpypi" {
-  for_each = { for k, v in var.repositories : k => v if v.is_django_commons_repo == false }
+  for_each = local.project_repositories
 
   environment         = "testpypi"
   repository          = each.key

--- a/terraform/resources-repo-admin-teams.tf
+++ b/terraform/resources-repo-admin-teams.tf
@@ -1,6 +1,6 @@
 # Define the admin team for each repository
 resource "github_team" "repo_admin_team" {
-  for_each = { for k, v in var.repositories : k => v if v.is_django_commons_repo == false }
+  for_each = local.project_repositories
 
   parent_team_id = github_team.repo_team[each.key].id
   name           = "${each.key}-admins"
@@ -10,7 +10,7 @@ resource "github_team" "repo_admin_team" {
 
 # Add the people to the team
 resource "github_team_members" "repo_admin_members" {
-  for_each = { for k, v in var.repositories : k => v if v.is_django_commons_repo == false }
+  for_each = local.project_repositories
 
   team_id = github_team.repo_admin_team[each.key].id
 
@@ -26,7 +26,7 @@ resource "github_team_members" "repo_admin_members" {
 
 # Define the team's permissions for the repositories
 resource "github_team_repository" "repo_admin_team_access" {
-  for_each   = { for k, v in var.repositories : k => v if v.is_django_commons_repo == false }
+  for_each   = local.project_repositories
   repository = each.key
   team_id    = github_team.repo_admin_team[each.key].id
   permission = "admin"

--- a/terraform/resources-repo-committer-teams.tf
+++ b/terraform/resources-repo-committer-teams.tf
@@ -1,6 +1,6 @@
 # Define the committers team for each repository
 resource "github_team" "repo_committer_team" {
-  for_each = { for k, v in var.repositories : k => v if v.is_django_commons_repo == false }
+  for_each = local.project_repositories
 
   parent_team_id = github_team.repo_team[each.key].id
   name           = "${each.key}-committers"

--- a/terraform/resources-repo-teams.tf
+++ b/terraform/resources-repo-teams.tf
@@ -1,6 +1,6 @@
 # Create the main repository team for Django Commons.
 resource "github_team" "repo_team" {
-  for_each = { for k, v in var.repositories : k => v if v.is_django_commons_repo == false }
+  for_each = local.project_repositories
 
   name        = each.key
   description = "Main team for the ${each.key} repository"
@@ -8,7 +8,7 @@ resource "github_team" "repo_team" {
 }
 # Add the people to the team
 resource "github_team_members" "repo_team_members" {
-  for_each = { for k, v in var.repositories : k => v if v.is_django_commons_repo == false }
+  for_each = local.project_repositories
 
   team_id = github_team.repo_team[each.key].id
 
@@ -27,7 +27,7 @@ resource "github_team_members" "repo_team_members" {
 }
 # Define the team's permissions for the repositories
 resource "github_team_repository" "repo_team_access" {
-  for_each   = { for k, v in var.repositories : k => v if v.is_django_commons_repo == false }
+  for_each   = local.project_repositories
   repository = each.key
   team_id    = github_team.repo_team[each.key].id
   permission = "triage"
@@ -37,7 +37,7 @@ resource "github_team_repository" "repo_team_access" {
 
 # This is used to enable automatic PR review requests
 resource "github_team_settings" "this" {
-  for_each = { for k, v in var.repositories : k => v if v.is_django_commons_repo == false }
+  for_each = local.project_repositories
 
   review_request_delegation {
     algorithm    = "LOAD_BALANCE"

--- a/terraform/resources-repos.tf
+++ b/terraform/resources-repos.tf
@@ -56,8 +56,9 @@ resource "github_repository" "this" {
     for_each = each.value.template != null ? [each.value.template] : []
 
     content {
-      owner      = "django-commons"
-      repository = template.value
+      owner                = template.value.owner
+      repository           = template.value.repository
+      include_all_branches = template.value.include_all_branches
     }
   }
 }

--- a/terraform/resources-repos.tf
+++ b/terraform/resources-repos.tf
@@ -35,6 +35,7 @@ resource "github_repository" "this" {
   topics                      = each.value.topics
   visibility                  = each.value.visibility
   vulnerability_alerts        = true
+  pages                       = each.value.pages
 
   dynamic "template" {
     for_each = each.value.template != null ? [each.value.template] : []

--- a/terraform/resources-repos.tf
+++ b/terraform/resources-repos.tf
@@ -35,7 +35,22 @@ resource "github_repository" "this" {
   topics                      = each.value.topics
   visibility                  = each.value.visibility
   vulnerability_alerts        = true
-  pages                       = each.value.pages
+  dynamic "pages" {
+    for_each = each.value.pages != null ? [each.value.pages] : []
+    content {
+      dynamic "source" {
+        for_each = pages.value.source != null ? [pages.value.source] : []
+        content {
+          branch = source.value.branch
+          path   = source.value.path
+        }
+      }
+      build_type = pages.value.build_type
+      cname      = pages.value.cname
+      html_url   = pages.value.html_url
+      url        = pages.value.url
+    }
+  }
 
   dynamic "template" {
     for_each = each.value.template != null ? [each.value.template] : []

--- a/terraform/tfstate.json
+++ b/terraform/tfstate.json
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.9.8",
-  "serial": 310,
+  "serial": 311,
   "lineage": "425397de-8394-a003-8a6c-bce854d9cc53",
   "outputs": {},
   "resources": [
@@ -1201,6 +1201,57 @@
           },
           "sensitive_attributes": [],
           "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "github_repository_collaborators",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/integrations/github\"]",
+      "instances": [
+        {
+          "index_key": "drf-excel",
+          "schema_version": 0,
+          "attributes": {
+            "id": "drf-excel",
+            "invitation_ids": {},
+            "repository": "drf-excel",
+            "team": [
+              {
+                "permission": "admin",
+                "team_id": "drf-excel-admins"
+              },
+              {
+                "permission": "maintain",
+                "team_id": "drf-excel-committers"
+              },
+              {
+                "permission": "pull",
+                "team_id": "security-team"
+              },
+              {
+                "permission": "triage",
+                "team_id": "drf-excel"
+              }
+            ],
+            "user": [
+              {
+                "permission": "admin",
+                "username": "FlipperPA"
+              },
+              {
+                "permission": "admin",
+                "username": "browniebroke"
+              },
+              {
+                "permission": "maintain",
+                "username": "rptmat57"
+              }
+            ]
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjAifQ=="
         }
       ]
     },

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -50,6 +50,18 @@ variable "repositories" {
     merge_commit_message        = optional(string, null)
     squash_merge_commit_title   = optional(string, null)
     squash_merge_commit_message = optional(string, null)
+    pages = optional(object({
+      source = optional(object({
+        branch = string
+        path   = optional(string, "")
+      }), null)
+      build_type = optional(string, "workflow") # legacy or workflow
+      cname      = optional(string, "")
+      html_url   = optional(string, "")
+      url        = optional(string, "")
+      custom_404 = optional(bool, null)
+      status     = optional(string, "built") # built or building
+    }), null)
   }))
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -32,11 +32,10 @@ variable "repositories" {
     has_downloads                   = optional(bool, true)
     homepage_url                    = optional(string, "")
     has_wiki                        = optional(bool, false)
-    is_template                     = optional(bool, false)
     push_allowances                 = optional(list(string), [])
     enable_branch_protection        = optional(bool, true)
     required_status_checks_contexts = optional(list(string), [])
-    template                        = optional(string)
+    is_template                     = optional(bool, false) # Is the repository a template repository
     topics                          = optional(list(string))
     visibility                      = optional(string, "public")
     is_django_commons_repo          = optional(bool, false)     # Do not create teams for repository
@@ -50,6 +49,8 @@ variable "repositories" {
     merge_commit_message        = optional(string, null)
     squash_merge_commit_title   = optional(string, null)
     squash_merge_commit_message = optional(string, null)
+
+    # Pages settings
     pages = optional(object({
       source = optional(object({
         branch = string
@@ -61,6 +62,13 @@ variable "repositories" {
       url        = optional(string, "")
       custom_404 = optional(bool, null)
       status     = optional(string, "built") # built or building
+    }), null)
+
+    # Template of the repository
+    template = optional(object({
+      owner                = string
+      repository           = string
+      include_all_branches = bool
     }), null)
   }))
 }


### PR DESCRIPTION
This looks like a big change but it is not really, just better organization:
- Support for GitHub pages for repositories => fix https://github.com/django-commons/controls/issues/62
- Fix the way we deal with repositories created from a template.
- Ensure all repository collaborators are managed by the terraform (i.e., remove manually added users from repository collaborators, see `plan` results here)
- Update `django-commons-playground` description and topics.
- Remove `template` from `django-tailwind-cli` (it is not from a template)
- Replace duplicate `{ for k, v in var.repositories : k => v if v.is_django_commons_repo == false }` with `local.project_repositories` defined once.