### PR TITLE
Add Django Brew episode

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ maintained. If you're interested in working on a specific project, go get to wor
 
 ## Django Commons Content
 
+- [Django Brew Episode 4: Spoiler Alert: DjangoCon US Recap, Open Source Maintenance, and Other Spooky Stories](https://djangobrew.com/episodes/16285007-episode-4-spoiler-alert-djangocon-us-recap-open-source-maintenance-and-other-spooky-stories)
+- ["Endorsing Django Packages"](https://softwarecrafts.uk/100-words/day-246) by [Andy Miller][https://github.com/nanorepublica/]
 - ["Django Commons"](https://www.ryancheley.com/2024/10/23/django-commons/) by [Ryan Cheley](github.com/ryancheley/):
   An introduction to Django Commons, explaining its goals, structure, and benefits for maintainers.
 - ["Django Commons"](https://simonwillison.net/2024/Oct/8/django-commons/) by Simon Willison:
@@ -88,7 +90,6 @@ maintained. If you're interested in working on a specific project, go get to wor
   A lightning talk from DjangoCon US 2024 introducing Django Commons.
 - ["Django Commons - A home for community-maintained Django packages"](https://www.better-simple.com/django/2024/05/22/looking-for-help-django-commons/) by [Tim Schilling](https://github.com/tim-schilling/):
   A call for help to start Django Commons.
-- ["Endorsing Django Packages"](https://softwarecrafts.uk/100-words/day-246) by [Andy Miller][https://github.com/nanorepublica/]
 
 ## Credits
 


### PR DESCRIPTION
The Django Brew podcast mentioned Django Commons and package maintenance about halfway through. 

This moves Andy's mention because it's reverse chronological order.