### PR TITLE
Fix gh command in add_member.yml

### DIFF
--- a/.github/workflows/add_member.yml
+++ b/.github/workflows/add_member.yml
@@ -85,7 +85,7 @@ jobs:
             --title "Add ${{ env.USERNAME }} to django-commons" \
             --body "Fix #${{ env.ISSUE_NUMBER }}" \
             --base main \
-            --head ${{ env.BRANCH_NAME }}
+            --head ${{ env.BRANCH_NAME }} \
             --label "New member"
         env:
           GITHUB_TOKEN: ${{ secrets.TERRAFORM_MANAGEMENT_GITHUB_TOKEN }}


### PR DESCRIPTION
I noticed that this action has been failing for new members. It looked like an easy fix.

Error message:
`--label: command not found`

Solution:
Add the missing line break character `\` to the `gh pr create` command block

Not sure how to test this other than running the action again on my membership request, for example.