### PR TITLE
Make the title clearer to avoid issues with < > wrappers

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-member.yml
+++ b/.github/ISSUE_TEMPLATE/new-member.yml
@@ -1,7 +1,7 @@
 name: New member
 description: Become a Django Commons member with the following form.
 labels: ["New member"]
-title: "✋ [MEMBER] - <your handle>"
+title: "✋ [MEMBER] - your_username_here"
 assignees: 'django-commons/admins'
 body:
   - type: markdown


### PR DESCRIPTION
We've seen a handful of issues created where users have included the wrapping `<` and `>` characters. I think this snakecase approach may be clearer that they aren't needed.