### PR TITLE
Fix new member workflow to handle username with extra spaces and `@`

### DIFF
--- a/.github/workflows/add_member.yml
+++ b/.github/workflows/add_member.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Get username to add
         id: get_username
         run:
-          python -c "print('USERNAME='+'${{ github.event.issue.title }}'.split(' - ')[1].strip().lstrip('@')" >> $GITHUB_ENV
+          python -c "print('USERNAME='+'${{ github.event.issue.title }}'.split(' - ')[1].strip().lstrip('@'))" >> $GITHUB_ENV
 
       - name: Validate add user request
         env:

--- a/.github/workflows/add_member.yml
+++ b/.github/workflows/add_member.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Get username to add
         id: get_username
         run:
-          python -c "print('USERNAME='+'${{ github.event.issue.title }}'.split(' - ')[1])" >> $GITHUB_ENV
+          python -c "print('USERNAME='+'${{ github.event.issue.title }}'.split(' - ')[1].strip().lstrip('@')" >> $GITHUB_ENV
 
       - name: Validate add user request
         env:


### PR DESCRIPTION
It's common for folks to request to join the org and specify their username as handle, with the `@` sign before. In this case, the GH action is unable to resolve the username: https://github.com/django-commons/membership/issues/230#issuecomment-3172575547

This attempt to make the wokflow a bit more robust by stripping extra leading or trailing spaces and leading `@` sign.