### PR TITLE
Reapply "Add Creativeklvn to django-commons (#258)"

### DIFF
--- a/terraform/production/org.tfvars
+++ b/terraform/production/org.tfvars
@@ -22,6 +22,7 @@ members = [
   "carltongibson",
   "cgl",
   "clintonb",
+  "Creativeklvn",
   "ddabble",
   "devatbosch",
   "dmpayton",


### PR DESCRIPTION
This reverts commit ab3f8ed09a6c9b82363c18979fb7a29e3201be1a.

@ryancheley I reverted the last commit, let the plan be applied then merged. Then reverted, the revert (reapplying the original commit).

The problem was that the merge commit changed the plan from what was on the PR. ~I'm going to disable merge commits on the repo to avoid this in the future.~ That's already done. It was the "update branch with merge" that may have been the problem.