### PR TITLE
Remove project selection from new member requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-member.yml
+++ b/.github/ISSUE_TEMPLATE/new-member.yml
@@ -16,12 +16,6 @@ body:
       placeholder: Keep it to 2-4 sentences.
     validations:
       required: true
-  - type: textarea
-    id: which-projects
-    attributes:
-      label: Which project(s) are you looking to contribute to?
-    validations:
-      required: false
   - type: checkboxes
     id: general
     attributes:


### PR DESCRIPTION
These selections require a follow-up PR (the person has to accept the org invite before they can be assigned to a team) and we have rarely used this. Instead, we'll rely on team change requests.