### PR TITLE
Zizmor warning clean-ups.

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: terraform apply
         # v1.44.0
@@ -40,7 +42,8 @@ jobs:
 
       - name: Commit changes
         if: ${{ always() }}
-        uses: devops-infra/action-commit-push@v0.10.0
+        # v0.10.0
+        uses: devops-infra/action-commit-push@b8c990ac36bac67f71133ad7ec3da1d7abf4d57e
         with:
           github_token: "${{ secrets.TERRAFORM_MANAGEMENT_GITHUB_TOKEN }}"
           commit_prefix: "[AUTO]"

--- a/.github/workflows/member-verification.yml
+++ b/.github/workflows/member-verification.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Check PR title format
         id: check-title

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: "${{ github.event.pull_request.head.ref }}"
+          persist-credentials: false
 
 
       - name: terraform fmt
@@ -29,7 +30,8 @@ jobs:
           path: "terraform"
 
       - name: Commit changes
-        uses: devops-infra/action-commit-push@v0.9.2
+        # v0.9.2
+        uses: devops-infra/action-commit-push@be5ba37125c79eb0016cbd8cc385f0aa160538c5
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           commit_prefix: "[AUTO]"
@@ -48,6 +50,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: terraform plan
         # v1.44.0


### PR DESCRIPTION
Don't persist the credentials in git.

Specifies the hash rather than a pinned version.