### PR TITLE
Trigger terraform actions when we change the plan and apply actions.

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - 'terraform/production/*.tfvars'
       - 'terraform/*.tf'
+      - '.github/workflows/apply.yml'
+      - '.github/workflows/plan.yml'
 
 concurrency:
   group: terraform-actions

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'terraform/production/*.tfvars'
       - 'terraform/*.tf'
+      - '.github/workflows/apply.yml'
+      # Do not trigger the plan action when it's been changed since this action has write permissions
 
 concurrency:
   group: terraform-actions


### PR DESCRIPTION
When plan.yml changes, only cause the apply action to run on merge to main. We shouldn't run the plan.yml when it's changed due to it having write permissions and running on pull request.