### PR TITLE
Explicitly maintain the credentials for add new member GHA.

### DIFF
--- a/.github/workflows/add_member.yml
+++ b/.github/workflows/add_member.yml
@@ -30,7 +30,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          persist-credentials: false
+          # This is the default, but it's required since we are performing
+          # Git operations later on.
+          persist-credentials: true
 
       - name: Get username to add
         id: get_username


### PR DESCRIPTION
This was broken in #331 and is causing the new member action to fail currently. https://github.com/django-commons/membership/actions/runs/20101658508/job/57673945849 