### PR TITLE
Remove the newline character from new member PR descriptions

### DIFF
--- a/.github/workflows/add_member.yml
+++ b/.github/workflows/add_member.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           gh pr create \
             --title "Add ${USERNAME} to django-commons" \
-            --body "Fix #${ISSUE_NUMBER}\n[New Member Playbook](https://github.com/django-commons/controls?tab=readme-ov-file#new-member-playbook)" \
+            --body "Fix #${ISSUE_NUMBER}. See next steps in [New Member Playbook](https://github.com/django-commons/controls?tab=readme-ov-file#new-member-playbook)" \
             --base main \
             --head ${BRANCH_NAME} \
             --label "New member"


### PR DESCRIPTION
This sidesteps the issue of having `\n` rendered on the description by making them separate sentences.

See https://github.com/django-commons/membership/pull/348 for an example of what this is fixing.