### PR TITLE
Revert "Add niltonpimentel02 to django-commons"

### DIFF
--- a/terraform/production/org.tfvars
+++ b/terraform/production/org.tfvars
@@ -83,7 +83,6 @@ members = [
   "mzemlickis",
   "nanorepublica",
   "Natim",
-  "niltonpimentel02",
   "okotdaniel",
   "oliverandrich",
   "ontowhee",


### PR DESCRIPTION
This reverts commit 3311b0ec58bf049cbb3c6a0628fe769b225ffac6.

I merged too quickly. Again.