### PR TITLE
Remove @p-r-a-v-i-n from design team members

### DIFF
--- a/terraform/org.tfvars
+++ b/terraform/org.tfvars
@@ -29,7 +29,6 @@ designers = [
   "Ndungu9039",
   "nwanduka",
   "okotdaniel",
-  "p-r-a-v-i-n",
   "Shrikantgiri25",
   "vinlawz",
   "Violette-Allotey",


### PR DESCRIPTION
Terraform keeps adding them back and they keep removing themself.

@p-r-a-v-i-n sorry about the noise, you kept getting added back by Terraform and I see you removed yourself again several times.