### PR TITLE
Remove deprecated `has_downloads` from terraform config

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -79,7 +79,6 @@ All changes should be made in `*.tfvars`:
         allow_update_branch = true # optional, default is true
         delete_branch_on_merge = true # optional, default is true
         has_discussions = true # optional, default is true
-        has_downloads = true # optional, default is true
         has_wiki = false # optional, default is false
         is_template = false # optional, default is false
         push_allowances = []

--- a/terraform/repositories.tfvars
+++ b/terraform/repositories.tfvars
@@ -207,7 +207,6 @@ repositories = {
     allow_update_branch    = true
     delete_branch_on_merge = true
     has_discussions        = true
-    has_downloads          = true
     has_wiki               = false
     is_template            = false
     push_allowances        = []

--- a/terraform/repositories/resources-repos.tf
+++ b/terraform/repositories/resources-repos.tf
@@ -25,7 +25,6 @@ resource "github_repository" "this" {
   archive_on_destroy          = true
   delete_branch_on_merge      = each.value.delete_branch_on_merge
   description                 = each.value.description
-  has_downloads               = each.value.has_downloads
   has_discussions             = each.value.has_discussions
   has_issues                  = true
   has_projects                = each.value.has_projects

--- a/terraform/repositories/variables.tf
+++ b/terraform/repositories/variables.tf
@@ -20,7 +20,6 @@ variable "repositories" {
     delete_branch_on_merge          = optional(bool, true)
     has_projects                    = optional(bool, true)
     has_discussions                 = optional(bool, true)
-    has_downloads                   = optional(bool, true)
     has_wiki                        = optional(bool, false)
     push_allowances                 = optional(list(string), [])
     required_status_checks_contexts = optional(list(string), [])


### PR DESCRIPTION
https://docs.github.com/en/rest/about-the-rest-api/breaking-changes?apiVersion=2026-03-10&versionId=free-pro-team%40latest&category=repos#:~:text=Remove%20deprecated%20has%5Fdownloads%20property%20from%20Repository%20response

We have this property enabled. Recently it apparently switched to false and Terraform is trying to set it back to true.

<img width="603" height="703" alt="afbeelding" src="https://github.com/user-attachments/assets/e2985b2c-303d-49e9-bd74-ffefcc96a8c1" />


Lets just remove this deprecated property altogether and not have it cause unexpected changes.