### PR TITLE
Add project maintenance governance documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,6 @@ contact_links:
   - name: Have an idea you'd like to discuss with other members?
     url: https://github.com/orgs/django-commons/discussions
     about: Please ask and answer questions here.
-  - name: Request to be an Admin
+  - name: Join Django Commons Admin Team
     url: https://forms.gle/ZDUtLcvmWUAES2RN8
     about: Interested in becoming a Django Commons admin? Fill out our interest form.

--- a/README.md
+++ b/README.md
@@ -53,17 +53,22 @@ and the community stronger.
 There are three teams for each repository. They each have different
 permissions.
 
-- [project-name]
-- [project-name]-committers
-- [project-name]-admins
+- `@django-commons/<project>` (the project members team)
+- `@django-commons/<project>-committers` (the project committers team)
+- `@django-commons/<project>-admins` (the project admin team)
 
-The general team [project-name] gives you triage permissions (assign issues, labels, etc).
+The project members team, `@django-commons/<project>`, gives you triage permissions (assign
+issues, labels, etc).
 
-The [project-name]-committers gives you permission to merge pull requests and push to main.
-They are people who generally maintain the project.
+The project committers team, `@django-commons/<project>-committers`, gives you permission to
+merge pull requests and push to main. They are the people who generally maintain the project.
 
-The [project-name]-admins gives you permissions to administrate the GitHub repo and release new versions to PyPI.
-This may be the same group of people that are on [project-name]-commiters.
+The project admin team, `@django-commons/<project>-admins`, gives you permissions to
+administrate the GitHub repo and release new versions to PyPI. This may be the same group of
+people that are on `@django-commons/<project>-committers`.
+
+These are distinct from the organization-wide teams, `@django-commons/admins` and
+`@django-commons/super-admins`, which administer Django Commons as a whole.
 
 ### Who can work on a project?
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ The project members team, `@django-commons/<project>`, gives you triage permissi
 issues, labels, etc).
 
 The project committers team, `@django-commons/<project>-committers`, gives you permission to
-merge pull requests and push to main. They are the people who generally maintain the project.
+merge pull requests and push to main via GitHub's `maintain` permission. It does not grant
+the ability to publish releases. They are the people who generally maintain the project.
 
 The project admin team, `@django-commons/<project>-admins`, gives you permissions to
 administrate the GitHub repo and release new versions to PyPI. This may be the same group of

--- a/django-commons.org/mkdocs.yml
+++ b/django-commons.org/mkdocs.yml
@@ -28,6 +28,8 @@ nav:
     - Decision Record: decision_record.md
     - Governance:
       - Django Commons: governance/django-commons.md
+      - Project Maintenance: governance/project-maintenance.md
+      - Response Timeframes: response-timeframes.md
     - Projects: projects.md
     - Team: team.md
     - Values: values.md

--- a/django-commons.org/mkdocs.yml
+++ b/django-commons.org/mkdocs.yml
@@ -26,7 +26,8 @@ nav:
   - Resources for Maintainers: maintainers-resources.md
   - Organization:
     - Decision Record: decision_record.md
-    - Governance: governance.md
+    - Governance:
+      - Django Commons: governance/django-commons.md
     - Projects: projects.md
     - Team: team.md
     - Values: values.md

--- a/docs/blog/posts/2026-02-03-recruiting-new-admins.md
+++ b/docs/blog/posts/2026-02-03-recruiting-new-admins.md
@@ -23,7 +23,7 @@ The admin team takes care of the administrative work of managing Django Commons 
 - Website maintenance: adding new projects to the website, adding and maintaining information
 - Administrative and funding tasks: governance decisions and docs, Terraform tooling, manage contributions on Thanks.dev and Open Collective, branding updates
 
-Read more about the [admin team](https://django-commons.org/governance/#admin-team).
+Read more about the [admin team](https://django-commons.org/governance/django-commons/#admin-team).
 
 ## How will I know if I'm selected?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,7 +30,8 @@ The project members team, `@django-commons/<project>`, gives you triage permissi
 issues, labels, etc).
 
 The project committers team, `@django-commons/<project>-committers`, gives you permission to
-merge pull requests and push to main. They are the people who generally maintain the project.
+merge pull requests and push to main via GitHub's `maintain` permission. It does not grant
+the ability to publish releases. They are the people who generally maintain the project.
 
 The project admin team, `@django-commons/<project>-admins`, gives you permissions to
 administrate the GitHub repo and release new versions to PyPI. This may be the same group of

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -46,7 +46,7 @@ maintained. If you're interested in working on a specific project, go get to wor
 - [best-practices](https://github.com/django-commons/best-practices): A sample project with best practices for Django Commons projects.
 - [membership](https://github.com/django-commons/membership): The public face for the organization. All issues by members and contributors should be created
   here. **If you're looking for where to ask a question, this is the place for you**
--
+
 ### Do we allow all packages or just Django-adjacent?
 
 Any package is welcome to join Django Commons so long as it has tangible benefits to the Django Community at large and the package benefits from being part of Django Commons OR it is about Django Specifically.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,17 +22,22 @@ and the community stronger.
 There are three teams for each repository. They each have different
 permissions.
 
-- [project-name]
-- [project-name]-committers
-- [project-name]-admins
+- `@django-commons/<project>` (the project members team)
+- `@django-commons/<project>-committers` (the project committers team)
+- `@django-commons/<project>-admins` (the project admin team)
 
-The general team [project-name] gives you triage permissions (assign issues, labels, etc).
+The project members team, `@django-commons/<project>`, gives you triage permissions (assign
+issues, labels, etc).
 
-The [project-name]-committers gives you permission to merge pull requests and push to main.
-They are people who generally maintain the project.
+The project committers team, `@django-commons/<project>-committers`, gives you permission to
+merge pull requests and push to main. They are the people who generally maintain the project.
 
-The [project-name]-admins gives you permissions to administrate the GitHub repo and release new versions to PyPI.
-This may be the same group of people that are on [project-name]-commiters.
+The project admin team, `@django-commons/<project>-admins`, gives you permissions to
+administrate the GitHub repo and release new versions to PyPI. This may be the same group of
+people that are on `@django-commons/<project>-committers`.
+
+These are distinct from the organization-wide teams, `@django-commons/admins` and
+`@django-commons/super-admins`, which administer Django Commons as a whole.
 
 ## Who can work on a project?
 

--- a/docs/governance/django-commons.md
+++ b/docs/governance/django-commons.md
@@ -54,7 +54,7 @@ Responsibilities/tasks include:
 Out of scope responsibilities/tasks:
 
 - Maintaining projects. This is the responsibility of the maintainers of the projects themselves. However, admin team members are free to contribute to projects as they see fit. There is just no expectation that they do so.
-- Yanking packages from PyPI - this should be done by project maintainers in coordination with the PyPI team. An exception is made when the project maintainer is [unresponsive](../unresponsive.md).
+- Yanking packages from PyPI - this should be done by project maintainers in coordination with the PyPI team. An exception is made when the project maintainer has not responded within the [response timeframes](../response-timeframes.md).
 
 Qualifications for admin members (any of the following):
 

--- a/docs/governance/django-commons.md
+++ b/docs/governance/django-commons.md
@@ -54,7 +54,7 @@ Responsibilities/tasks include:
 Out of scope responsibilities/tasks:
 
 - Maintaining projects. This is the responsibility of the maintainers of the projects themselves. However, admin team members are free to contribute to projects as they see fit. There is just no expectation that they do so.
-- Yanking packages from PyPI - this should be done by project maintainers in coordination with the PyPI team. An exception is made when the project maintainer is [unresponsive](unresponsive.md).
+- Yanking packages from PyPI - this should be done by project maintainers in coordination with the PyPI team. An exception is made when the project maintainer is [unresponsive](../unresponsive.md).
 
 Qualifications for admin members (any of the following):
 
@@ -71,7 +71,7 @@ The admin team may change around September.  In August, the admin team will put 
 
 At this time, the process for selecting new admin team members is based around the current admin team interviewing candidates it deems suitable. An election process was considered but as of April 2025, the admin team feels Django Commons has not matured enough for elections to provide tangible benefits over self-selection.
 
-We strive to have a team [reflective of our values](values.md).
+We strive to have a team [reflective of our values](../values.md).
 
 ### Means of communication
 

--- a/docs/governance/django-commons.md
+++ b/docs/governance/django-commons.md
@@ -40,7 +40,7 @@ Responsibilities/tasks include:
 - Respond to inquiries from the community on the [Discussion forum](https://github.com/orgs/django-commons/discussions).
 - Manage all team rotation schedules, making sure that every team is actively staffed in a sustainable manner.
 - Encourage people from diverse backgrounds to join one of the teams.
-- Provide resources and facilitate projects seeking new or additional maintainers. Help find new maintainers for projects that need them.
+- Provide resources and facilitate projects seeking new or additional maintainers. Help find new maintainers for projects that need them, following [Project Maintenance Governance](project-maintenance.md).
 - Facilitate discovery of maintenance best practices.
 - Conduct check-ins with project maintainers and our community.
 - Maintain this document and other documents that describe how Django Commons operates.
@@ -50,10 +50,11 @@ Responsibilities/tasks include:
 - Supporting projects maintainers in handling security reports by providing advice or guidance.
 - Being a backup contact point for security reporters when project maintainers fail to respond to a security report.
 - In cases where a maintainer is unresponsive, the admin team may take over the project to fix the security issue at their discretion.
+- Cutting releases for projects under [Commons Stewardship](project-maintenance.md#commons-stewardship). This is not a regular duty. It applies only to projects that have been determined to be dormant, and is limited to minor releases that unblock the downstream ecosystem.
 
 Out of scope responsibilities/tasks:
 
-- Maintaining projects. This is the responsibility of the maintainers of the projects themselves. However, admin team members are free to contribute to projects as they see fit. There is just no expectation that they do so.
+- Maintaining projects. This is the responsibility of the maintainers of the projects themselves. However, admin team members are free to contribute to projects as they see fit. There is just no expectation that they do so. The exception is a project under [Commons Stewardship](project-maintenance.md#commons-stewardship), where admins take on a deliberately limited caretaker role.
 - Yanking packages from PyPI - this should be done by project maintainers in coordination with the PyPI team. An exception is made when the project maintainer has not responded within the [response timeframes](../response-timeframes.md).
 
 Qualifications for admin members (any of the following):

--- a/docs/governance/project-maintenance.md
+++ b/docs/governance/project-maintenance.md
@@ -27,7 +27,7 @@ A project is determined to be dormant when any of the following occur:
 * A lack of activity across issues, pull requests, commits, and releases from the project admins for a period of **six months**
 * A lack of a release within **six months** of a major Django version release (5.0, 5.1, 5.2, etc.)
 * A **critical bug** has gone unaddressed for a significant period
-* A **security vulnerability** has been reported and not acted on
+* A **security vulnerability** has been reported and not acknowledged within the timeframe for its severity, as defined in [response timeframes](../response-timeframes.md)
 
 #### Review of applications for maintainers from the Django Commons Community
 

--- a/docs/governance/project-maintenance.md
+++ b/docs/governance/project-maintenance.md
@@ -24,17 +24,17 @@ A project has an unresponsive maintainer, a lack of forward compatibility, and p
 
 A project is determined to be dormant when any of the following occur:
 
-* A lack of activity across issues, pull requests, commits, and releases from the project admins for a period of **six months**  
-* A lack of a release within **six months** of a major Django version release (5.0, 5.1, 5.2, etc.)  
-* A **critical bug** has gone unaddressed for a significant period  
+* A lack of activity across issues, pull requests, commits, and releases from the project admins for a period of **six months**
+* A lack of a release within **six months** of a major Django version release (5.0, 5.1, 5.2, etc.)
+* A **critical bug** has gone unaddressed for a significant period
 * A **security vulnerability** has been reported and not acted on
 
 #### Review of applications for maintainers from the Django Commons Community
 
 When a project has been determined to be dormant, members of the Django Commons community may put themselves forward as maintainers of the project. The admins will review the applicant and decide based on:
 
-1. Tenure of membership with Django Commons, Django, and Python communities  
-2. Work already done on the project, both merged and unmerged PRs  
+1. Tenure of membership with Django Commons, Django, and Python communities
+2. Work already done on the project, both merged and unmerged PRs
 3. Engagement with the project maintainer as evidenced by comments on PRs and/or discussions in the repos discussions (if they exist)
 
 ### Commons Stewardship
@@ -47,7 +47,7 @@ The Django Commons admins have direct administrative control to ensure the healt
 
 **What admins will not do:**
 
-* Actively develop the project as a team. Admins can participate as individuals, but not in an official capacity.  
+* Actively develop the project as a team. Admins can participate as individuals, but not in an official capacity.
 * Perform major refactors. That requires one or more engaged project admins who can maintain and support those changes over time.
 
 ### Archived
@@ -60,7 +60,7 @@ Having archived packages is a normal outcome in open source. If no contributor s
 
 ## Contributor Trust Ladder for Dormant and Archived Projects
 
-> **Note:** This section applies only to **dormant and archived projects** being adopted by a new contributor. Active projects with existing maintainers are self-organizing—current maintainers decide when and how to onboard new contributors, committers, or co-maintainers without Django Commons involvement.
+> **Note:** This section applies only to **dormant and archived projects** being adopted by a new contributor. Active projects with existing maintainers are self-organizing — current maintainers decide when and how to onboard new contributors, committers, or co-maintainers without Django Commons involvement.
 
 Django Commons takes a case-by-case approach to granting access to new contributors for abandoned projects. The goal is to avoid placing excessive operational burden on the admin team while still ensuring trust is established before handing over control.
 
@@ -74,8 +74,8 @@ The following staged path applies.
 
 During this stage, anyone is welcome to contribute to the project without requiring any special permissions beyond a standard fork-and-PR workflow.
 
-* There is no expectation that a contributor will advance; some contributors may be happy to stay at this level indefinitely.  
-* Contributors who are interested and show consistent, high-quality engagement are welcome to join the Committers Team for the project.  
+* There is no expectation that a contributor will advance; some contributors may be happy to stay at this level indefinitely.
+* Contributors who are interested and show consistent, high-quality engagement are welcome to join the Committers Team for the project.
 * A person can request to join by [creating an issue](https://github.com/django-commons/membership/issues/new?template=admin-request.yml) explaining why they want to contribute and what their plans are for the project.
 
 #### Project Committers Team
@@ -84,13 +84,13 @@ During this stage, anyone is welcome to contribute to the project without requir
 
 Contributors who have demonstrated reliable judgment may be invited to join the committers team, which grants:
 
-* Permission to create branches directly in the repository  
+* Permission to create branches directly in the repository
 * Commit access to non-protected branches
 
 The following remain restricted to Django Commons administrators:
 
-* Merging into the main/protected branch  
-* Cutting releases and publishing to PyPI  
+* Merging into the main/protected branch
+* Cutting releases and publishing to PyPI
 * Changing repository settings, branch protection rules, or secrets
 
 If a project lacks any admins, the Django Commons admins continue to review and approve all releases and will actively collaborate with the contributor on significant changes before they land.
@@ -103,7 +103,7 @@ After sustained, demonstrated trustworthiness as a committer, including sound ju
 
 The new permissions are:
 
-* The ability to publish releases  
+* The ability to publish releases
 * Define the governance for the project
 
 Progression is not automatic or time-based. It requires a conscious decision by Django Commons admins, ideally discussed openly in the membership repository. A contributor can be moved back to a previous stage if serious concerns arise.
@@ -116,8 +116,8 @@ If a contributor has a clearly established track record, like a strong commit hi
 
 A short call or interview with Django Commons admins is a valid path to establishing trust. Relevant signals include:
 
-* Talks or presentations at Python or Django conferences or meetups  
-* Attendance or organizing of such events  
+* Talks or presentations at Python or Django conferences or meetups
+* Attendance or organizing of such events
 * Other demonstrable community involvement
 
 Release access is always decided on a case-by-case basis by the admins. There is no automatic progression to release access regardless of which path a contributor takes.

--- a/docs/governance/project-maintenance.md
+++ b/docs/governance/project-maintenance.md
@@ -1,0 +1,124 @@
+# Project Maintenance Governance
+
+<!-- [Google Doc Link](https://docs.google.com/document/d/1LmUZszX4a0C9ess6c1WDIkWUrc5HMtIY22JMPs3sWvY/edit?usp=sharing) -->
+
+## Overview
+
+Django Commons creates the conditions for maintainership to transfer smoothly so that when maintainers step back, the community has a clear path to step in.
+
+This document will outline the various states a project can be in, how a project transitions between them, and where support is provided.
+
+---
+
+## Maintenance States
+
+### Healthy
+
+A project has a responsive maintainer, clear ownership, regular releases, and an active repository.
+
+### Dormant
+
+A project has an unresponsive maintainer, a lack of forward compatibility, and potentially community complaints.
+
+#### Determining a project to be dormant
+
+A project is determined to be dormant when any of the following occur:
+
+* A lack of activity across issues, pull requests, commits, and releases from the project admins for a period of **six months**  
+* A lack of a release within **six months** of a major Django version release (5.0, 5.1, 5.2, etc.)  
+* A **critical bug** has gone unaddressed for a significant period  
+* A **security vulnerability** has been reported and not acted on
+
+#### Review of applications for maintainers from the Django Commons Community
+
+When a project has been determined to be dormant, members of the Django Commons community may put themselves forward as maintainers of the project. The admins will review the applicant and decide based on:
+
+1. Tenure of membership with Django Commons, Django, and Python communities  
+2. Work already done on the project, both merged and unmerged PRs  
+3. Engagement with the project maintainer as evidenced by comments on PRs and/or discussions in the repos discussions (if they exist)
+
+### Commons Stewardship
+
+The Django Commons admins have direct administrative control to ensure the health of the ecosystem. This is a temporary state, and projects aren't meant to be here long term. Projects should either have new maintainers identified or be archived.
+
+**What admins will do:**
+
+* Make minor releases to unblock downstream Django applications from upgrading dependencies. These releases should be minor in substance and may involve small changes, such as when Django moved to a single `STORAGES` setting.
+
+**What admins will not do:**
+
+* Actively develop the project as a team. Admins can participate as individuals, but not in an official capacity.  
+* Perform major refactors. That requires one or more engaged project admins who can maintain and support those changes over time.
+
+### Archived
+
+No active maintenance is expected. The repository is retained for historical or referential purposes.
+
+Having archived packages is a normal outcome in open source. If no contributor steps forward to adopt an abandoned project, archiving is a valid and expected path.
+
+---
+
+## Contributor Trust Ladder for Dormant and Archived Projects
+
+> **Note:** This section applies only to **dormant and archived projects** being adopted by a new contributor. Active projects with existing maintainers are self-organizing—current maintainers decide when and how to onboard new contributors, committers, or co-maintainers without Django Commons involvement.
+
+Django Commons takes a case-by-case approach to granting access to new contributors for abandoned projects. The goal is to avoid placing excessive operational burden on the admin team while still ensuring trust is established before handing over control.
+
+### For contributors new to open source or without a strong public profile:
+
+The following staged path applies.
+
+#### Open Contribution
+
+*Goal: Establish a track record of quality contributions. This level is aligned with the `members` project team in the repository configuration.*
+
+During this stage, anyone is welcome to contribute to the project without requiring any special permissions beyond a standard fork-and-PR workflow.
+
+* There is no expectation that a contributor will advance; some contributors may be happy to stay at this level indefinitely.  
+* Contributors who are interested and show consistent, high-quality engagement are welcome to join the Committers Team for the project.  
+* A person can request to join by [creating an issue](https://github.com/django-commons/membership/issues/new?template=admin-request.yml) explaining why they want to contribute and what their plans are for the project.
+
+#### Project Committers Team
+
+*Goal: Enable a trusted contributor to work more autonomously on non-release work. This level is aligned with the `committers` project team in the repository configuration.*
+
+Contributors who have demonstrated reliable judgment may be invited to join the committers team, which grants:
+
+* Permission to create branches directly in the repository  
+* Commit access to non-protected branches
+
+The following remain restricted to Django Commons administrators:
+
+* Merging into the main/protected branch  
+* Cutting releases and publishing to PyPI  
+* Changing repository settings, branch protection rules, or secrets
+
+If a project lacks any admins, the Django Commons admins continue to review and approve all releases and will actively collaborate with the contributor on significant changes before they land.
+
+#### Project Admin Team
+
+*Goal: Formally hand stewardship of the project to a trusted maintainer. This level is aligned with the `admins` project team in the repository configuration.*
+
+After sustained, demonstrated trustworthiness as a committer, including sound judgment on security, responsiveness to feedback, and alignment with Django Commons values, a contributor may be elevated to full maintainer.
+
+The new permissions are:
+
+* The ability to publish releases  
+* Define the governance for the project
+
+Progression is not automatic or time-based. It requires a conscious decision by Django Commons admins, ideally discussed openly in the membership repository. A contributor can be moved back to a previous stage if serious concerns arise.
+
+### For contributors with a strong open source profile:
+
+If a contributor has a clearly established track record, like a strong commit history, active public repositories, or prior open source work, admins may grant commit access directly, skipping the early stages. Release access may follow at admin discretion.
+
+### For contributors assessed via a direct conversation:
+
+A short call or interview with Django Commons admins is a valid path to establishing trust. Relevant signals include:
+
+* Talks or presentations at Python or Django conferences or meetups  
+* Attendance or organizing of such events  
+* Other demonstrable community involvement
+
+Release access is always decided on a case-by-case basis by the admins. There is no automatic progression to release access regardless of which path a contributor takes.
+

--- a/docs/governance/project-maintenance.md
+++ b/docs/governance/project-maintenance.md
@@ -56,6 +56,8 @@ No active maintenance is expected. The repository is retained for historical or 
 
 Having archived packages is a normal outcome in open source. If no contributor steps forward to adopt an abandoned project, archiving is a valid and expected path.
 
+If the original maintainer or a new contributor later wants to revive an archived project, the Contributor Trust Ladder below applies the same way it does for dormant projects. Reach out to the Django Commons admins (@django-commons/admins) to start that conversation.
+
 ---
 
 ## Contributor Trust Ladder for Dormant and Archived Projects
@@ -126,6 +128,8 @@ The new permissions are:
 * Define the governance for the project
 
 Progression is not automatic or time-based. It requires a conscious decision by the Django Commons admins, ideally discussed openly in the membership repository. A contributor can be moved back to a previous stage if serious concerns arise.
+
+If an original maintainer becomes active again after a new Project Admin has taken over, both parties are expected to have a direct conversation to determine the project's direction going forward. Any differences that can't be resolved between them should be raised to the Django Commons admins (@django-commons/admins) for a final decision.
 
 Adopting a project does not come with the ability to take it out of Django Commons. See [Requirements for Outgoing Repositories for more information](https://github.com/django-commons/membership/blob/main/outgoing_repo_requirements.md).
 

--- a/docs/governance/project-maintenance.md
+++ b/docs/governance/project-maintenance.md
@@ -127,6 +127,8 @@ The new permissions are:
 
 Progression is not automatic or time-based. It requires a conscious decision by the Django Commons admins, ideally discussed openly in the membership repository. A contributor can be moved back to a previous stage if serious concerns arise.
 
+Adopting a project does not come with the ability to take it out of Django Commons. See [Requirements for Outgoing Repositories for more information](https://github.com/django-commons/membership/blob/main/outgoing_repo_requirements.md).
+
 ### For contributors with a strong open source profile:
 
 If a contributor has a clearly established track record, like a strong commit history, active public repositories, or prior open source work, the Django Commons admins may grant commit access directly, skipping the early stages. Release access may follow at their discretion.

--- a/docs/governance/project-maintenance.md
+++ b/docs/governance/project-maintenance.md
@@ -31,7 +31,7 @@ A project is determined to be dormant when any of the following occur:
 
 #### Review of applications for maintainers from the Django Commons Community
 
-When a project has been determined to be dormant, members of the Django Commons community may put themselves forward as maintainers of the project. The admins will review the applicant and decide based on:
+When a project has been determined to be dormant, members of the Django Commons community may put themselves forward as maintainers of the project. The Django Commons admins (`@django-commons/admins`) will review the applicant and decide based on:
 
 1. Tenure of membership with Django Commons, Django, and Python communities
 2. Work already done on the project, both merged and unmerged PRs
@@ -39,7 +39,7 @@ When a project has been determined to be dormant, members of the Django Commons 
 
 ### Commons Stewardship
 
-The Django Commons admins have direct administrative control to ensure the health of the ecosystem. This is a temporary state, and projects aren't meant to be here long term. Projects should either have new maintainers identified or be archived.
+The Django Commons admins (`@django-commons/admins`) have direct administrative control to ensure the health of the ecosystem. This is a temporary state, and projects aren't meant to be here long term. Projects should either have new maintainers identified or be archived.
 
 **What admins will do:**
 
@@ -62,7 +62,7 @@ Having archived packages is a normal outcome in open source. If no contributor s
 
 > **Note:** This section applies only to **dormant and archived projects** being adopted by a new contributor. Active projects with existing maintainers are self-organizing — current maintainers decide when and how to onboard new contributors, committers, or co-maintainers without Django Commons involvement.
 
-Django Commons takes a case-by-case approach to granting access to new contributors for abandoned projects. The goal is to avoid placing excessive operational burden on the admin team while still ensuring trust is established before handing over control.
+Django Commons takes a case-by-case approach to granting access to new contributors for abandoned projects. The goal is to avoid placing excessive operational burden on the Django Commons admins (`@django-commons/admins`) while still ensuring trust is established before handing over control.
 
 ### For contributors new to open source or without a strong public profile:
 
@@ -70,7 +70,7 @@ The following staged path applies.
 
 #### Open Contribution
 
-*Goal: Establish a track record of quality contributions. This level is aligned with the `members` project team in the repository configuration.*
+*Goal: Establish a track record of quality contributions. This level requires no team membership at all.*
 
 During this stage, anyone is welcome to contribute to the project without requiring any special permissions beyond a standard fork-and-PR workflow.
 
@@ -80,24 +80,24 @@ During this stage, anyone is welcome to contribute to the project without requir
 
 #### Project Committers Team
 
-*Goal: Enable a trusted contributor to work more autonomously on non-release work. This level is aligned with the `committers` project team in the repository configuration.*
+*Goal: Enable a trusted contributor to work more autonomously on non-release work. This level is aligned with the project committers team, `@django-commons/<project>-committers`.*
 
 Contributors who have demonstrated reliable judgment may be invited to join the committers team, which grants:
 
 * Permission to create branches directly in the repository
 * Commit access to non-protected branches
 
-The following remain restricted to Django Commons administrators:
+The following remain restricted to the project admin team (`@django-commons/<project>-admins`) and the Django Commons admins (`@django-commons/admins`):
 
 * Merging into the main/protected branch
 * Cutting releases and publishing to PyPI
 * Changing repository settings, branch protection rules, or secrets
 
-If a project lacks any admins, the Django Commons admins continue to review and approve all releases and will actively collaborate with the contributor on significant changes before they land.
+If a project lacks a project admin team, the Django Commons admins continue to review and approve all releases and will actively collaborate with the contributor on significant changes before they land.
 
 #### Project Admin Team
 
-*Goal: Formally hand stewardship of the project to a trusted maintainer. This level is aligned with the `admins` project team in the repository configuration.*
+*Goal: Formally hand stewardship of the project to a trusted maintainer. This level is aligned with the project admin team, `@django-commons/<project>-admins`.*
 
 After sustained, demonstrated trustworthiness as a committer, including sound judgment on security, responsiveness to feedback, and alignment with Django Commons values, a contributor may be elevated to full maintainer.
 
@@ -106,19 +106,19 @@ The new permissions are:
 * The ability to publish releases
 * Define the governance for the project
 
-Progression is not automatic or time-based. It requires a conscious decision by Django Commons admins, ideally discussed openly in the membership repository. A contributor can be moved back to a previous stage if serious concerns arise.
+Progression is not automatic or time-based. It requires a conscious decision by the Django Commons admins, ideally discussed openly in the membership repository. A contributor can be moved back to a previous stage if serious concerns arise.
 
 ### For contributors with a strong open source profile:
 
-If a contributor has a clearly established track record, like a strong commit history, active public repositories, or prior open source work, admins may grant commit access directly, skipping the early stages. Release access may follow at admin discretion.
+If a contributor has a clearly established track record, like a strong commit history, active public repositories, or prior open source work, the Django Commons admins may grant commit access directly, skipping the early stages. Release access may follow at their discretion.
 
 ### For contributors assessed via a direct conversation:
 
-A short call or interview with Django Commons admins is a valid path to establishing trust. Relevant signals include:
+A short call or interview with the Django Commons admins is a valid path to establishing trust. Relevant signals include:
 
 * Talks or presentations at Python or Django conferences or meetups
 * Attendance or organizing of such events
 * Other demonstrable community involvement
 
-Release access is always decided on a case-by-case basis by the admins. There is no automatic progression to release access regardless of which path a contributor takes.
+Release access is always decided on a case-by-case basis by the Django Commons admins. There is no automatic progression to release access regardless of which path a contributor takes.
 

--- a/docs/governance/project-maintenance.md
+++ b/docs/governance/project-maintenance.md
@@ -82,10 +82,12 @@ During this stage, anyone is welcome to contribute to the project without requir
 
 *Goal: Enable a trusted contributor to work more autonomously on non-release work. This level is aligned with the project committers team, `@django-commons/<project>-committers`.*
 
-Contributors who have demonstrated reliable judgment may be invited to join the committers team, which grants:
+Contributors who have demonstrated reliable judgment may be invited to join the project committers team, which grants:
 
-* Permission to create branches directly in the repository
-* Commit access to non-protected branches
+* Creating branches directly in the repository
+* Pushing to and merging into `main`
+* Reviewing and merging pull requests
+* Managing issues, discussions, and non-sensitive repository settings
 
 The following remain restricted to the project admin team (`@django-commons/<project>-admins`) and the Django Commons admins (`@django-commons/admins`):
 

--- a/docs/governance/project-maintenance.md
+++ b/docs/governance/project-maintenance.md
@@ -75,8 +75,25 @@ The following staged path applies.
 During this stage, anyone is welcome to contribute to the project without requiring any special permissions beyond a standard fork-and-PR workflow.
 
 * There is no expectation that a contributor will advance; some contributors may be happy to stay at this level indefinitely.
-* Contributors who are interested and show consistent, high-quality engagement are welcome to join the Committers Team for the project.
-* A person can request to join by [creating an issue](https://github.com/django-commons/membership/issues/new?template=admin-request.yml) explaining why they want to contribute and what their plans are for the project.
+* Contributors who are interested and show consistent, high-quality engagement are welcome to move up the ladder.
+* A person can request to advance by [creating an issue](https://github.com/django-commons/membership/issues/new?template=admin-request.yml) explaining why they want to contribute and what their plans are for the project.
+
+#### Project Members Team
+
+*Goal: Let a contributor help manage the project's backlog and assign themselves to issues. This level is aligned with the project members team, `@django-commons/<project>`.*
+
+The project members team grants GitHub's `triage` permission:
+
+* Assign themselves and others to issues
+* Applying and removing labels
+* Closing, reopening, and marking duplicate issues and pull requests
+* Requesting pull request reviews
+
+It grants no write access, so a member at this level still contributes code through the standard fork-and-PR workflow.
+
+This is a deliberately low bar. Anyone can request to join by [creating an issue](https://github.com/django-commons/membership/issues/new?template=admin-request.yml) naming the project and describing how they want to help. The Django Commons admins will generally grant it on evidence of genuine engagement, such as a few merged pull requests or sustained, constructive participation in the project's issues.
+
+Because triage permission cannot modify code or releases, a request at this level is low risk and should be easy to approve. It can be revoked just as easily if it goes unused or is misused.
 
 #### Project Committers Team
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,12 +75,12 @@ Django Commons has a few bands of members. There is the broad membership role
 - Project Members
     - The group of members dedicated to a specific repository.
     - This role grants the members Triage permission for the repository.
-    - Mention with `@django-commons/<repository>`
+    - Mention with `@django-commons/<project>`
 - Project Committers
     - The group of members who can commit changes to main for a repository.
     - This role grants the members Commit permission for the repository.
-    - Mention with `@django-commons/<repository>-committers`
+    - Mention with `@django-commons/<project>-committers`
 - Project Admins:
     - The group of members who are the admins for a repository.
     - This role grants the members Admin permission for the repository.
-    - Mention with `@django-commons/<repository>-admins`
+    - Mention with `@django-commons/<project>-admins`

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,13 +74,13 @@ Django Commons has a few bands of members. There is the broad membership role
     - Mention with `@django-commons/designers`
 - Project Members
     - The group of members dedicated to a specific repository.
-    - This role grants the members Triage permission for the repository.
+    - This role grants the members GitHub's Triage permission for the repository.
     - Mention with `@django-commons/<project>`
 - Project Committers
-    - The group of members who can commit changes to main for a repository.
-    - This role grants the members Commit permission for the repository.
+    - The group of members who can commit changes to main for a repository, but not publish releases.
+    - This role grants the members GitHub's Maintain permission for the repository.
     - Mention with `@django-commons/<project>-committers`
 - Project Admins:
     - The group of members who are the admins for a repository.
-    - This role grants the members Admin permission for the repository.
+    - This role grants the members GitHub's Admin permission for the repository.
     - Mention with `@django-commons/<project>-admins`

--- a/docs/response-timeframes.md
+++ b/docs/response-timeframes.md
@@ -1,0 +1,11 @@
+# Response Timeframes
+
+The table below defines the timeframes in which we expect a maintainer to respond to a reported security vulnerability. For the purposes of 'responsiveness' an acknowledgement is sufficient. There isn't an expectation that a fix will be implemented within the time frames below.
+
+| CVE Level | Timeframe |
+| ---       | ---       |
+| Critical  | 1 week    |
+| High      | 2 weeks   |
+| Medium    | 4 weeks   |
+| Low       | 8 weeks   |
+| None      | 16 weeks  |

--- a/docs/unresponsive.md
+++ b/docs/unresponsive.md
@@ -1,9 +1,0 @@
-The table below outlines unresponsive maintainers. For the purposes of 'responsiveness' an acknowledgement is sufficient. There isn't an expectation that a fix will be implemented within the time frames below.
-
-| CVE Level | Timeframe |
-| ---       | ---       |
-| Critical  | 1 week    |
-| High      | 2 weeks   |
-| Medium    | 4 weeks   |
-| Low       | 8 weeks   |
-| None      | 16 weeks  |


### PR DESCRIPTION
This adds governance around managing projects that have gone dormant or are archived. The purpose of these changes are to allow us to accept dormant and archived projects, as well as provide a pathway for projects to go that route within Django Commons.


I also used Claude to revise our existing documentation to be a little more consistent across the board based on our proposed changes.